### PR TITLE
[MM-30226][MM-39255] Allow a post to be sent when you do CMD + ENTER …

### DIFF
--- a/components/edit_post_modal/edit_post_modal.jsx
+++ b/components/edit_post_modal/edit_post_modal.jsx
@@ -296,14 +296,18 @@ class EditPostModal extends React.PureComponent {
     }
 
     handleKeyDown = (e) => {
-        const ctrlKeyCombo = (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey;
+        const {ctrlSend, codeBlockOnCtrlEnter} = this.props;
+
+        const ctrlOrMetaKeyPressed = e.ctrlKey || e.metaKey;
+        const ctrlKeyCombo = ctrlOrMetaKeyPressed && !e.altKey && !e.shiftKey;
+        const ctrlEnterKeyCombo = (ctrlSend || codeBlockOnCtrlEnter) && Utils.isKeyPressed(e, KeyCodes.ENTER) && ctrlOrMetaKeyPressed;
         const markdownHotkey = Utils.isKeyPressed(e, KeyCodes.B) || Utils.isKeyPressed(e, KeyCodes.I);
 
         // listen for line break key combo and insert new line character
         if (Utils.isUnhandledLineBreakKeyCombo(e)) {
             e.stopPropagation(); // perhaps this should happen in all of these cases? or perhaps Modal should not be listening?
             this.setState({editText: Utils.insertLineBreakFromKeyEvent(e)});
-        } else if (this.props.ctrlSend && Utils.isKeyPressed(e, KeyCodes.ENTER) && e.ctrlKey === true) {
+        } else if (ctrlEnterKeyCombo) {
             this.handleEdit();
         } else if (Utils.isKeyPressed(e, KeyCodes.ESCAPE) && !this.state.showEmojiPicker) {
             this.handleHide();

--- a/components/edit_post_modal/edit_post_modal.test.jsx
+++ b/components/edit_post_modal/edit_post_modal.test.jsx
@@ -407,21 +407,49 @@ describe('components/EditPostModal', () => {
         var wrapper = shallowWithIntl(createEditPost({ctrlSend: true}), {context: options.get()});
         var instance = wrapper.instance();
         instance.handleEdit = jest.fn();
-        instance.handleKeyDown({keyCode: 1, ctrlKey: true, ...eventMethods});
+
+        // Test with Control Key (Windows)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: true, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).toBeCalled();
+
+        wrapper = shallowWithIntl(createEditPost({ctrlSend: true}));
+        instance = wrapper.instance();
+        instance.handleEdit = jest.fn();
+
+        // Test with Command Key (Mac)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: false, metaKey: true, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: true, ...eventMethods});
         expect(instance.handleEdit).toBeCalled();
 
         wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
         instance = wrapper.instance();
         instance.handleEdit = jest.fn();
-        instance.handleKeyDown({keyCode: 1, ctrlKey: true, ...eventMethods});
+
+        // Test with Control Key (Windows)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: true, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
-        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, ...eventMethods});
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: true, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+
+        wrapper = shallowWithIntl(createEditPost({ctrlSend: false}));
+        instance = wrapper.instance();
+        instance.handleEdit = jest.fn();
+
+        // Test with Command Key (Mac)
+        instance.handleKeyDown({keyCode: 1, ctrlKey: false, metaKey: true, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: false, ...eventMethods});
+        expect(instance.handleEdit).not.toBeCalled();
+        instance.handleKeyDown({key: Constants.KeyCodes.ENTER[0], keyCode: Constants.KeyCodes.ENTER[1], ctrlKey: false, metaKey: true, ...eventMethods});
         expect(instance.handleEdit).not.toBeCalled();
     });
 


### PR DESCRIPTION
…on Mac with 'Allow all messages' to be sent via CMD + ENTER (#7031)

* make a post be able to send when you do command enter when editing post

* fix linting

* Edit task to take into control mac command key

* fix linting

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- Has server changes (please link here)
- Has redux changes (please link here)
- Has mobile changes (please link here)

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.
-->